### PR TITLE
Fix for list placements.

### DIFF
--- a/snippets/ol.php
+++ b/snippets/ol.php
@@ -1,7 +1,7 @@
-<?php if ($prev && $prev->type() !== 'ol'): ?>
+<?php if (is_null($prev) || $prev->type() !== 'ol'): ?>
 <ol>
 <?php endif ?>
 <li><?= $content ?></li>
-<?php if ($next && $next->type() !== 'ol'): ?>
+<?php if (is_null($next) || && $next->type() !== 'ol'): ?>
 </ol>
 <?php endif ?>

--- a/snippets/ol.php
+++ b/snippets/ol.php
@@ -2,6 +2,6 @@
 <ol>
 <?php endif ?>
 <li><?= $content ?></li>
-<?php if (is_null($next) || && $next->type() !== 'ol'): ?>
+<?php if (is_null($next) || $next->type() !== 'ol'): ?>
 </ol>
 <?php endif ?>

--- a/snippets/ol.php
+++ b/snippets/ol.php
@@ -1,7 +1,7 @@
-<?php if (is_null($prev) || $prev->type() !== 'ol'): ?>
+<?php if ($prev === null || $prev->type() !== 'ol'): ?>
 <ol>
 <?php endif ?>
 <li><?= $content ?></li>
-<?php if (is_null($next) || $next->type() !== 'ol'): ?>
+<?php if ($next === null || $next->type() !== 'ol'): ?>
 </ol>
 <?php endif ?>

--- a/snippets/ul.php
+++ b/snippets/ul.php
@@ -2,6 +2,6 @@
 <ul>
 <?php endif ?>
 <li><?= $content ?></li>
-<?php if (is_null($next) || && $next->type() !== 'ul'): ?>
+<?php if (is_null($next) || $next->type() !== 'ul'): ?>
 </ul>
 <?php endif ?>

--- a/snippets/ul.php
+++ b/snippets/ul.php
@@ -1,7 +1,7 @@
-<?php if ($prev && $prev->type() !== 'ul'): ?>
+<?php if (is_null($prev) || $prev->type() !== 'ul'): ?>
 <ul>
 <?php endif ?>
 <li><?= $content ?></li>
-<?php if ($next && $next->type() !== 'ul'): ?>
+<?php if (is_null($next) || && $next->type() !== 'ul'): ?>
 </ul>
 <?php endif ?>

--- a/snippets/ul.php
+++ b/snippets/ul.php
@@ -1,7 +1,7 @@
-<?php if (is_null($prev) || $prev->type() !== 'ul'): ?>
+<?php if ($prev === null || $prev->type() !== 'ul'): ?>
 <ul>
 <?php endif ?>
 <li><?= $content ?></li>
-<?php if (is_null($next) || $next->type() !== 'ul'): ?>
+<?php if ($next === null || $next->type() !== 'ul'): ?>
 </ul>
 <?php endif ?>


### PR DESCRIPTION
Change to look at the if $prev or $next is null, if they are output the open/close tags.

Current implementation won't output the open/close tags if there are no blocks before or after.