### PR TITLE
Support custom block names with a dash

### DIFF
--- a/lib/Block.php
+++ b/lib/Block.php
@@ -137,7 +137,8 @@ class Block
             throw new InvalidArgumentException('The block type is missing');
         }
 
-        $customName = 'Kirby\\Editor\\' . $params['type'] . 'Block';
+        $name = str_replace(['.', '-', '_'], '', $params['type']);
+        $customName = 'Kirby\\Editor\\' . $name . 'Block';
         $className  = class_exists($customName) ? $customName : 'Kirby\\Editor\\Block';
 
         return new $className($params, $blocks);


### PR DESCRIPTION
I'm working on a custom block named `html5-video`. I added this line that I copied over from `Kirby\Cms\AppPlugins\extensionsFromFolders` to remove the dash from the block name so that the model loading works:

```php
load([
  'kirby\\editor\\html5videoblock' => __DIR__ . '/Html5VideoBlock.php'
]);
```

What do you think?