### PR TITLE
Add line breaks to intro block

### DIFF
--- a/examples/intro-block/index.js
+++ b/examples/intro-block/index.js
@@ -11,4 +11,7 @@ editor.block("intro", {
 
   // icon for the blocks dropdown
   icon: "text",
+  
+  // Enable line breaks
+  breaks: true,
 });


### PR DESCRIPTION
## Describe the PR

This adds `breaks: true` to the intro example. This setting has to set manually after extending the paragraph block and therefore needs to be documented.

## Related issues

https://github.com/getkirby/editor/issues/190
https://github.com/getkirby/editor/issues/207

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
