### PR TITLE
fix(ImageBlock): change image resolution to use `filename` instead of `guid`

### DIFF
--- a/examples/info-block/index.css
+++ b/examples/info-block/index.css
@@ -1,6 +1,6 @@
 /**
  * Each block is automatically wrapped in a div
- * with a generated class name that follos the scheme
+ * with a generated class name that follows the scheme
  * `k-editor-$type-block` You can use this to scope
  * all your css within a block
  */

--- a/lib/ImageBlock.php
+++ b/lib/ImageBlock.php
@@ -18,7 +18,7 @@ class ImageBlock extends Block
     public function image()
     {
         try {
-            return $this->kirby()->api()->parent($this->attrs()->guid()->value());
+            return $this->parent()->file($this->attrs()->filename()->value());
         } catch (Throwable $e) {
             return null;
         }
@@ -34,7 +34,7 @@ class ImageBlock extends Block
         $image = $this->image();
 
         $attrs = [
-            'image'   => $image ? $image->id() : $this->attrs()->src(),
+            'image'   => $image ? $image->filename() : $this->attrs()->src(),
             'alt'     => $this->attrs()->alt(),
             'link'    => $this->attrs()->link(),
             'class'   => $this->attrs()->css(),
@@ -50,6 +50,7 @@ class ImageBlock extends Block
 
         if ($image = $this->image()) {
             $data['attrs'] = array_merge($data['attrs'] ?? [], [
+                'filename'  => $image->filename(),
                 'guid'  => $image->panelUrl(true),
                 'ratio' => $image->ratio(),
                 'src'   => $image->resize(800)->url()

--- a/src/components/Blocks/Image.vue
+++ b/src/components/Blocks/Image.vue
@@ -131,6 +131,7 @@ export default {
           guid: response.link,
           src: response.url,
           id: response.id,
+          filename: response.filename,
           ratio: response.dimensions.ratio
         });
       });


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
Changes the ImageBlock to use the `filename` for image resolution, instead of `guid`. This fixes the current issue that if the page URL changes, the image blocks breaks.

## Related issues

<!-- PR relates to issues in the `editor` repo: -->
- Fixes #217

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
