### PR TITLE
Fix same images rendering

### DIFF
--- a/lib/ImageBlock.php
+++ b/lib/ImageBlock.php
@@ -18,6 +18,12 @@ class ImageBlock extends Block
     public function image()
     {
         try {
+            // for the guid used in 1.0.2 and earlier versions
+            // @deprecated 1.1.0
+            if ($this->attrs()->filename()->isEmpty()) {
+                return $this->kirby()->api()->parent($this->attrs()->guid()->value());
+            }
+
             return $this->parent()->file($this->attrs()->filename()->value());
         } catch (Throwable $e) {
             return null;
@@ -50,10 +56,10 @@ class ImageBlock extends Block
 
         if ($image = $this->image()) {
             $data['attrs'] = array_merge($data['attrs'] ?? [], [
-                'filename'  => $image->filename(),
-                'guid'  => $image->panelUrl(true),
-                'ratio' => $image->ratio(),
-                'src'   => $image->resize(800)->url()
+                'filename' => $image->filename(),
+                'guid'     => $image->panelUrl(true),
+                'ratio'    => $image->ratio(),
+                'src'      => $image->resize(800)->url()
             ]);
 
             if ($toStorage === true) {

--- a/lib/ImageBlock.php
+++ b/lib/ImageBlock.php
@@ -20,7 +20,7 @@ class ImageBlock extends Block
         try {
             // for the guid used in 1.0.2 and earlier versions
             // @deprecated 1.1.0
-            if ($this->attrs()->filename()->isEmpty()) {
+            if ($this->attrs()->filename()->isEmpty() === true) {
                 return $this->kirby()->api()->parent($this->attrs()->guid()->value());
             }
 


### PR DESCRIPTION
## Describe the PR

In the new version, since `filename` data is not yet available, the `guid` data will be used temporarily (`@deprecated 1.1.0`). Since `filename` data will now be available when the page is updated, we may remove this lines in future releases. I think this might be the next minor version as v1.1.0

## Related issues

<!-- PR relates to issues in the `editor` repo: -->

- Fixes #246 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
