### PR TITLE
Use the image object in snippets

### DIFF
--- a/snippets/image.php
+++ b/snippets/image.php
@@ -1,11 +1,11 @@
 <?php if ($block->isNotEmpty()): ?>
 <figure<?= attr(['class' => $attrs->css()->value()], ' ') ?>>
   <?php if ($attrs->link()->isNotEmpty()): ?>
-  <a href="<?= $attrs->link()->toUrl() ?>">
-    <img src="<?= $src ?>" alt="<?= $attrs->alt() ?>">
-  </a>
+    <a href="<?= $attrs->link()->toUrl() ?>">
+      <?= $image ?>
+    </a>
   <?php else: ?>
-  <img src="<?= $src ?>" alt="<?= $attrs->alt() ?>">
+    <?= $image ?>
   <?php endif ?>
 
   <?php if ($attrs->caption()->isNotEmpty()): ?>


### PR DESCRIPTION
## Describe the PR

Use the image object in snippets. This allow direct access to resize() and other image functions. 

## Related issues

The current code confuses peoples. See https://forum.getkirby.com/t/new-editor-referencing-image-metadata/15905/5?u=gagarine

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
