### PR TITLE
make block position definable in the list of blocks #185

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -102,9 +102,8 @@ export default {
   },
   beforeCreate() {
 
-    Object.keys(window.editor.blocks).forEach(key => {
-
-      const block = window.editor.blocks[key];
+    Object.keys(window.editor.blocks).forEach(index => {
+      const [key, block] = window.editor.blocks[index];
 
       if (block.extends && window.editor.blocks[block.extends]) {
         block.extends = window.editor.blocks[block.extends];

--- a/src/components/Plugins.js
+++ b/src/components/Plugins.js
@@ -1,10 +1,11 @@
 window.editor = {
-  blocks: {},
-  block(type, params) {
+  blocks: [],
+  block(type, params, position) {
     const defaults = {
       type: type,
       icon: "page",
     };
+    const positionMatch = /(after|before):(\S+)/.exec(position);
 
     // extend the params with the defaults
     params = {
@@ -21,6 +22,24 @@ window.editor = {
       placeholder: params.placeholder,
     };
 
-    this.blocks[type] = params;
+    // add block to blocks array
+    if (position && positionMatch !== null && this.blocks.findIndex(b => b[0] === positionMatch[2]) !== -1) {
+      // add after/before a given type if position parameter is given and sibling block isset
+      // find position of siblings type
+      let siblingsIndex = this.blocks.findIndex(b => b[0] === positionMatch[2]);
+
+      // add new block before/after sibling
+      switch (positionMatch[1]) {
+        case 'before':
+          this.blocks.splice(siblingsIndex, 0, [type,params])
+          break;
+        case 'after':
+        default:
+          this.blocks.splice(siblingsIndex + 1, 0, [type,params])
+      }
+    } else {
+      // add block add the end of blocks
+      this.blocks.push([type, params]);
+    }
   }
 };


### PR DESCRIPTION
## Describe the PR

So far, custom blocks are simply added at the end of the standard blocks. In some cases, however, it is practical to place your own blocks at a defined position (e.g. en h4 block after the h3 block).

## Related issues

[Sort blockTypes #185](https://github.com/getkirby/editor/issues/185)

## Ready?

- [ ]  Added unit tests for fixed bug/feature
- [ ]  Passing all unit tests
- [ ]  Fixed code style issues with CS fixer and composer fix
- [x]  Added in-code documentation (if needed)